### PR TITLE
parallel Computation of Transition Matrix

### DIFF
--- a/pathpy/HigherOrderNetwork.py
+++ b/pathpy/HigherOrderNetwork.py
@@ -35,7 +35,7 @@ import scipy.linalg as _la
 import scipy as _sp
 
 import functools as fu
-import pathos as pa
+import multiprocessing as _mp
 
 from pathpy.Log import Log
 from pathpy.Log import Severity
@@ -946,11 +946,11 @@ class HigherOrderNetwork:
         # partially calculate some functions, so that it may be passed to the pool
         partiallyCalculated = fu.partial(HigherOrderNetwork.partialTransitionMatrix, self.nodes, D, includeSubPaths)
 
+        a = 0
         # initializing the processingPool
-        pool = pa.multiprocessing.ProcessingPool(nodes = n_chunks)
-
-        # calculating the elements for the sparse matrix
-        a = pool.amap(partiallyCalculated, dicts).get()
+        with _mp.Pool(n_chunks) as pool:
+            # calculating the elements for the sparse matrix
+            a = pool.map(partiallyCalculated, dicts)
 
         # assigning the correct data to the variables, due to the way the amag().get() returns values
         row = _np.hstack([a[i][0] for i in range(n_chunks)])

--- a/pathpy/HigherOrderNetwork.py
+++ b/pathpy/HigherOrderNetwork.py
@@ -920,7 +920,7 @@ class HigherOrderNetwork:
         
         edges_length= len(self.edges)
 
-        n_chunks = n_cores
+        n_chunks = self.cores
 
         ### Splits dictionary into roughly equal parts which will be passed on to a worker pool
         def split_dict_equally(input_dict, chunks=n_chunks):

--- a/pathpy/HigherOrderNetwork.py
+++ b/pathpy/HigherOrderNetwork.py
@@ -951,6 +951,7 @@ class HigherOrderNetwork:
         with _mp.Pool(n_chunks) as pool:
             # calculating the elements for the sparse matrix
             a = pool.map(partiallyCalculated, dicts)
+            pool.close()
 
         # assigning the correct data to the variables, due to the way the amag().get() returns values
         row = _np.hstack([a[i][0] for i in range(n_chunks)])


### PR DESCRIPTION
can compute the Transition Matrix in Parallel
-> is much faster for large matrices, where as it slightly slows down small matrix calculations
requires pathos